### PR TITLE
Add alternative API that doesn't require custom it

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change log for hspec-slow project
 
+## Version 0.2.0.1 - 2020.11.26
+Riskbook takes over maintainership
+
+
+
 ## Version 0.2.0.0 - 2020.11.04
 
 Add alternative api that doesn't require using custom it.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,9 @@
+# Change log for hspec-slow project
+
+## Version 0.2.0.0 - 2020.11.04
+
+Add alternative api that doesn't require using custom it.
+
+## Version 0.1.0.0 - 2016.04.24
+
+Initial release

--- a/hspec-slow.cabal
+++ b/hspec-slow.cabal
@@ -1,5 +1,5 @@
 name:                hspec-slow
-version:             0.1.0.0
+version:             0.2.0.0
 synopsis:            Find slow test cases
 description:         Records and prints out slow Hspec tests
 homepage:            https://github.com/bobjflong/hspec-slow#readme
@@ -10,7 +10,10 @@ maintainer:          robertjflong@gmail.com
 copyright:           2016 Bob Long
 category:            Testing
 build-type:          Simple
--- extra-source-files:
+extra-source-files:
+    Readme.md
+    LICENSE
+    Changelog.md
 cabal-version:       >=1.10
 
 library
@@ -22,6 +25,8 @@ library
                        , transformers
                        , mtl
                        , hspec
+                       , call-stack
+                       , hspec-core
   default-language:    Haskell2010
 
 test-suite hspec-slow-test

--- a/hspec-slow.cabal
+++ b/hspec-slow.cabal
@@ -19,7 +19,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Test.Hspec.Slow
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.7 && < 4.15
                        , stm
                        , time
                        , transformers

--- a/hspec-slow.cabal
+++ b/hspec-slow.cabal
@@ -11,7 +11,7 @@ copyright:           2016 Bob Long
 category:            Testing
 build-type:          Simple
 extra-source-files:
-    Readme.md
+    readme.md
     LICENSE
     Changelog.md
 cabal-version:       >=1.10

--- a/hspec-slow.cabal
+++ b/hspec-slow.cabal
@@ -44,4 +44,4 @@ test-suite hspec-slow-test
 
 source-repository head
   type:     git
-  location: https://github.com/bobjflong/hspec-slow
+  location: https://github.com/riskbook/hspec-slow

--- a/hspec-slow.cabal
+++ b/hspec-slow.cabal
@@ -25,7 +25,7 @@ library
                        , transformers
                        , mtl
                        , hspec
-                       , hspec-core
+                       , hspec-core >= 2.0.0 && < 3.0
   default-language:    Haskell2010
 
 test-suite hspec-slow-test

--- a/hspec-slow.cabal
+++ b/hspec-slow.cabal
@@ -25,7 +25,6 @@ library
                        , transformers
                        , mtl
                        , hspec
-                       , call-stack
                        , hspec-core
   default-language:    Haskell2010
 

--- a/hspec-slow.cabal
+++ b/hspec-slow.cabal
@@ -1,20 +1,22 @@
+cabal-version:       >=1.10
 name:                hspec-slow
-version:             0.2.0.0
+version:             0.2.0.1
 synopsis:            Find slow test cases
 description:         Records and prints out slow Hspec tests
-homepage:            https://github.com/bobjflong/hspec-slow#readme
 license:             BSD3
 license-file:        LICENSE
-author:              Bob Long
-maintainer:          robertjflong@gmail.com
+author:              Bob Long, riskbook <support@riskbook.com>
+maintainer:          riskbook <support@riskbook.com>
 copyright:           2016 Bob Long
 category:            Testing
 build-type:          Simple
+Homepage:            https://github.com/riskbook/hspec-slow
+Bug-reports:         https://github.com/riskbook/hspec-slow/issues
+Tested-with:         GHC==8.8.3
 extra-source-files:
     readme.md
     LICENSE
     Changelog.md
-cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+‼️ **This package is now redundant, as hspec added support for timing.**
+
 ## hspec-slow
 
 Track and display slow specs in Hspec runs.

--- a/readme.md
+++ b/readme.md
@@ -59,3 +59,25 @@ Slow examples:
 Finished in 4.0024 seconds
 3 examples, 0 failures
 ```
+
+## hspec slow everything
+
+`Main.hs`:
+```
+module Main where
+
+import qualified Spec
+import Test.Hspec.Slow
+import Test.Hspec(hspec)
+import ClassyPrelude
+
+main :: IO ()
+main = do
+  config <- configure 2
+  hspec $ timeThese config Spec.spec
+```
+`Spec.hs`:
+```
+{-# OPTIONS_GHC -fno-warn-implicit-prelude #-}
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}
+```

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,8 @@ main = do
         1 `shouldBe` 1
 ```
 
+Checkout [hspec slow everything](#hspec-slow-everything) to run this on your entire test suite.
+
 ## Example Output
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,14 @@
-‼️ **This package is now redundant, as hspec added support for timing.**
+<div align="center">
+
+‼️ **This package is now redundant, as hspec [added support for timing](https://hackage.haskell.org/package/hspec-2.11.14/changelog#changes-in-280).** ‼️
+
+</div>
+
+
+---
+
+<details>
+  <summary>Click to expand the old docs</summary>
 
 ## hspec-slow
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,31 @@
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
+
+let
+
+  inherit (nixpkgs) pkgs;
+
+  f = { mkDerivation, base, hspec, mtl, stdenv, stm, time
+      , transformers
+      }:
+      mkDerivation {
+        pname = "hspec-slow";
+        version = "0.1.0.0";
+        src = ./.;
+        libraryHaskellDepends = [ base hspec mtl stm time transformers ];
+        testHaskellDepends = [ base hspec mtl stm ];
+        homepage = "https://github.com/bobjflong/hspec-slow#readme";
+        description = "Find slow test cases";
+        license = stdenv.lib.licenses.bsd3;
+      };
+
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
+
+  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+
+  drv = variant (haskellPackages.callPackage f {});
+
+in
+
+  if pkgs.lib.inNixShell then drv.env else drv

--- a/src/Test/Hspec/Slow.hs
+++ b/src/Test/Hspec/Slow.hs
@@ -14,7 +14,6 @@ import           Control.Monad.Reader
 import           Control.Monad.STM
 import           Data.Time.Clock
 import           Test.Hspec
-import           Data.CallStack
 import           Data.Maybe
 import           Test.Hspec.Core.Spec
 
@@ -59,7 +58,6 @@ slowReport s = do
     slows <- readTVarIO (tracker s)
     putStrLn "Slow examples:"
     mapM_ (\(t, v) -> putStrLn $ show v ++ ": " ++ t) slows
-
 
 timedHspec :: SlowConfiguration -> (Timer -> SpecWith ()) -> IO ()
 timedHspec t x = hspec $ (afterAll_ . slowReport) t $ x (timed t)


### PR DESCRIPTION
At riskbook we have a fairly large test suite, adding a custom `it` to that test suite isn't done easily. This alternative 'testThese' method should allow you to run hspec slow on entire test suites without any customization. 
These changes don't impact the existing API at all. 

An example of the output is as follows:

```
Slow examples:
2.072315639s: ../riskbook-io-test/src/Handler/AdminSpec.hs[62:5]
        updates company and saves its organisation
2.294750009s: ../riskbook-io-test/src/Handler/PackSpec.hs[159:3]
        cedent can share a risk pack to a broker
```

The descriptions come from the test items themselves, as do the source locations.